### PR TITLE
Allo to scan large files

### DIFF
--- a/alfviral/src/main/java/com/fegor/alfresco/security/antivirus/InStreamScan.java
+++ b/alfviral/src/main/java/com/fegor/alfresco/security/antivirus/InStreamScan.java
@@ -174,6 +174,9 @@ public final class InStreamScan implements VirusScanMode {
 			
 			if (socket != null)
 				socket.close();
+
+			if (data != null)
+				data.close();
 		}
 
 		/*

--- a/alfviral/src/main/java/com/fegor/alfresco/security/antivirus/InStreamScan.java
+++ b/alfviral/src/main/java/com/fegor/alfresco/security/antivirus/InStreamScan.java
@@ -40,7 +40,7 @@ public final class InStreamScan implements VirusScanMode {
 
 	private final Logger logger = Logger.getLogger(InStreamScan.class);
 
-	private byte[] data;
+	private InputStream data;
 	private int chunkSize = 4096;
 	private int port;
 	private String host;
@@ -111,8 +111,9 @@ public final class InStreamScan implements VirusScanMode {
 	 */
 	@Override
 	public int scan() throws IOException {
-		int i = 0;
+		int bytesRead;
 		int result = 0;
+		byte[] buffer = new byte[chunkSize];
 
 		/*
 		 * create socket
@@ -143,16 +144,12 @@ public final class InStreamScan implements VirusScanMode {
 			dataOutputStream.writeBytes("zINSTREAM\0");
 
 			if (logger.isDebugEnabled()) {
-				logger.debug(getClass().getName() + "Send stream for  " + data.length + " bytes");
+				logger.debug(getClass().getName() + "Send stream for  " + data.available() + " bytes");
 			}
 
-			while (i < data.length) {
-				if (i + chunkSize >= data.length) {
-					chunkSize = data.length - i;
-				}
-				dataOutputStream.writeInt(chunkSize);
-				dataOutputStream.write(data, i, chunkSize);
-				i += chunkSize;
+			while ((bytesRead = data.read(buffer)) != -1) {
+				dataOutputStream.writeInt(bytesRead);
+				dataOutputStream.write(buffer, 0, bytesRead);
 			}
 
 			dataOutputStream.writeInt(0);
@@ -251,7 +248,7 @@ public final class InStreamScan implements VirusScanMode {
 	/**
 	 * @param data
 	 */
-	public void setData(byte[] data) {
+	public void setData(InputStream data) {
 		this.data = data;
 	}
 

--- a/alfviral/src/main/java/com/fegor/alfresco/security/antivirus/InStreamScan.java
+++ b/alfviral/src/main/java/com/fegor/alfresco/security/antivirus/InStreamScan.java
@@ -21,6 +21,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.InetSocketAddress;
+import java.io.InputStream;
 import java.net.Socket;
 import java.net.SocketException;
 

--- a/alfviral/src/main/java/com/fegor/alfresco/services/AntivirusServiceImpl.java
+++ b/alfviral/src/main/java/com/fegor/alfresco/services/AntivirusServiceImpl.java
@@ -179,7 +179,7 @@ public class AntivirusServiceImpl implements AntivirusService {
 						inStreamScan.setHost(inStreamHost);
 						inStreamScan.setPort(inStreamPort);
 						inStreamScan.setTimeout(inStreamTimeout);
-						inStreamScan.setData(contentReader.getContentString().getBytes());
+						inStreamScan.setData(contentReader.getContentInputStream());
 						res = inStreamScan.scan(nodeRef);
 					}
 


### PR DESCRIPTION
contentReader.getContentString() is not suitable for large files and cannot be handled by the JVM and Exceptions are thrown. As a consequence, the file upload is rejected in this case.
so this pull request will fix this problem and we will use contentReader.getContentInputStream() instead of contentReader.getContentString(), to handle larger files